### PR TITLE
[modify] keras version is not matched

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 tensorflow==1.14.0
-keras==2.3
+keras==2.2.4
 imgaug==0.2.6
 opencv-python
 Pillow


### PR DESCRIPTION
required keras version seems 2.2.4 but requirements.txt is targeted 2.3.
So (or perhaps) error occurred like below.

  "xxx/miniconda3/envs/yolo/lib/python3.6/site-packages/tensorflow/python/framework/graph_util_impl.py",
  line 302, in convert_variables_to_constants
      raise ValueError("Cannot find the variable that is an input "
	      ValueError: Cannot find the variable that is an input to
	      the ReadVariableOp.